### PR TITLE
Change docs submodule to HTTPS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "docs"]
 	path = docs
-	url = git@github.com:padrino/padrino-docs.git
+	url = https://github.com/padrino/padrino-docs.git
 	branch = master


### PR DESCRIPTION
Fixes inability to clone due to permission issues. The average use should be able to clone and hack easily.

Please let me know if this is just an issue with my git setup, however.

Error message when using SSH instead of HTTPS:

``` sh
$ git submodule update
Cloning into 'docs'...
Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
Clone of 'git@github.com:padrino/padrino-docs.git' into submodule path 'docs' failed
```
