### PR TITLE
Restore blog categories

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -37,6 +37,35 @@ helpers do
   def guides_by_chapter
     guides.group_by { |c| c.data.chapter }
   end
+
+  # blog-categories
+  def categories(page)
+    category_array(page.data[:categories])
+  end
+
+  def category_path(category)
+    "/category/#{category.parameterize}.html"
+  end
+
+  def all_categories
+    @all_categories ||= Hash[all_categories_unsorted.sort]
+  end
+
+  def category_array(categories)
+    (categories || "Uncategorized").split(" ")
+  end
+
+  private
+
+  def all_categories_unsorted
+    Hash.new { [] }.tap do |all_categories|
+      blog.articles.each do |article|
+        categories(article).each do |ac|
+          all_categories[ac] <<= article
+        end
+      end
+    end
+  end
 end
 
 # General configuration
@@ -61,6 +90,7 @@ activate :search_engine_sitemap,
   exclude_if: -> (resource) {
     # Exclude all paths from sitemap that are sub-date indexes
     resource.path.match(/[0-9]{4}(\/[0-9]{2})*.html/)
+    resource.path.match(/category\/*/)
   },
   default_change_frequency: 'weekly'
 activate :robots,
@@ -86,6 +116,13 @@ ready do
       proxy "guides/#{chapter}/#{title}", path.join('/'), locals: locals
     end
   end
+  sitemap.resources
+    .map { |r| (r.data["categories"] || "Uncategorized").split(" ") }
+    .flatten
+    .uniq
+    .each do |category|
+    proxy "/category/#{category.parameterize}.html", "category.html", locals: { category: category }
+  end
 end
 
 # Development-specific configuration
@@ -93,6 +130,8 @@ configure :development do
   activate :livereload
   activate :disqus, :shortname => nil
 end
+
+ignore 'category.html.slim'
 
 # Build-specific configuration
 configure :build do

--- a/source/_partials/_blog_article.slim
+++ b/source/_partials/_blog_article.slim
@@ -8,6 +8,12 @@
     = "Posted on #{blog_article.date.strftime('%B %d, %Y')}"
     - unless blog_article.data.author.nil?
       = " by #{blog_article.data.author}"
+    =< "| categories:"
+    - blog_article.data.categories.split(" ").each_with_index do |category, index|
+      - if index == blog_article.data.categories.split(" ").size - 1
+        =< link_to "#{category}", category_path(category)
+      - else
+        =< link_to "#{category},", category_path(category)
 
   = blog_article.body
 

--- a/source/categories.html.slim
+++ b/source/categories.html.slim
@@ -1,0 +1,5 @@
+h2 Categories
+ul
+  - all_categories.each do |category, articles|
+    li
+      = link_to "#{category} (#{articles.size})", category_path(category)

--- a/source/category.html.slim
+++ b/source/category.html.slim
@@ -1,0 +1,10 @@
+h1 Articles in category #{category.gsub(",", "")}
+
+ul
+  - if all_categories[category]
+    - all_categories[category].each_with_index do |article, i|
+      li
+        = link_to article.title, article
+        span<
+          | (#{article.date.strftime('%B %e, %Y')})
+

--- a/source/category.html.slim
+++ b/source/category.html.slim
@@ -8,3 +8,5 @@ ul
         span<
           | (#{article.date.strftime('%B %e, %Y')})
 
+= link_to "Overview of all categories", "/categories"
+


### PR DESCRIPTION
This will fix #11. 

Here is what the layout will be linked in the blog-posts:

![blog_categories](https://cloud.githubusercontent.com/assets/264708/14408302/4361bff2-feef-11e5-817c-5c07d3ba1e1b.png)

And the category page:

![blog_categories_detailed](https://cloud.githubusercontent.com/assets/264708/14408310/8886697a-feef-11e5-8613-e9a1aa39a885.png)

@angeloashmore do you think the presentation of the categories is good enough?
