### PR TITLE
Serve llms.txt and llms-full.txt for AI agents

### DIFF
--- a/source/llms-full.txt
+++ b/source/llms-full.txt
@@ -1,0 +1,1 @@
+../docs/llms-full.txt

--- a/source/llms.txt
+++ b/source/llms.txt
@@ -1,0 +1,1 @@
+../docs/llms.txt


### PR DESCRIPTION
Symlink `llms.txt` and `llms-full.txt` from the docs submodule into `source/` so they're served at padrinorb.com/llms.txt and padrinorb.com/llms-full.txt.

Follows the same pattern as the existing `guides` and `blog` symlinks. Middleman config already handles `*.txt` with `layout: false` (line 3 of config.rb).

Depends on padrino/padrino-docs#158 which adds the llms.txt files to the docs repo.